### PR TITLE
Minor tweaks

### DIFF
--- a/papers/p1729r4.bs
+++ b/papers/p1729r4.bs
@@ -105,13 +105,12 @@ if (auto result = std::scan<std::string, int>("answer = 42", "{} = {}")) {
   //            scanned
   //            values
 
-  // result == true
   // result->range() gives an empty range (result->begin() == result->end())
   // key == "answer"
   // value == 42
 } else {
-  // We'll end up here if we had an error
-  // Inspect the returned scan_error with result.error()
+  // We'll end up here if we had an error.
+  // Inspect the returned scan_error with result.error().
 }
 ```
 
@@ -135,13 +134,13 @@ auto [i, x, str, j, y, k] = result->values();
 // k == 0123
 ```
 
-Reading from an arbitrary range {#example-range}
--------------------------------
+Reading from a range {#example-range}
+--------------------
 
 ```c++
 std::string input{"123 456"};
 if (auto result = std::scan<int>(std::views::reverse(input), "{}")) {
-  // If only a single value is returned, it can be inspected with result->value()
+  // If only a single value is returned, it can be accessed with result->value()
   // result->value() == 654
 }
 ```


### PR DESCRIPTION
A few minor tweaks and a fix:

* Remove `result == true` because it's ill-formed and we already demonstrate how to check if result is contextually convertible to `bool`.
* Add missing punctuation.
* "arbitrary range" -> "range" because we don't support input ranges and therefore it's not arbitrary.
* "inspected" -> "accessed" because the former gives an impression that the value can only be read while we should be able to move it.

