### PR TITLE
Add white-space property for code elements

### DIFF
--- a/dev/fmt.css
+++ b/dev/fmt.css
@@ -20,6 +20,7 @@
   margin-left: 1em;
 }
 
+code,
 pre > code.decl {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Currently the result of `fmt::format("{:>10}", color::blue)` is displayed inline as ` blue` with a collapsed whitespace, which is confusing.